### PR TITLE
feat: Welford heatmap normalisation

### DIFF
--- a/crates/total-viewsheds/src/compute.rs
+++ b/crates/total-viewsheds/src/compute.rs
@@ -4,16 +4,10 @@ use color_eyre::{eyre::Ok, Result};
 
 /// Handles all the computations.
 pub struct Compute<'compute> {
-    /// Where to run the kernel computations
-    backend: crate::config::Backend,
-    /// What to compute.
-    process: Vec<crate::config::Process>,
+    /// User configuration.
+    config: ComputeConfig,
     /// Vulkan GPU manager
     vulkan: Option<super::vulkan::Vulkan>,
-    /// The OS's state directory for saving our cache into.
-    state_directory: Option<std::path::PathBuf>,
-    /// Output directory
-    output_directory: Option<std::path::PathBuf>,
     /// Storage interface for conputed ring (viewshed) data.
     storage: Option<crate::output::ring_data::Storage>,
     /// The Digital Elevation Model that we're computing.
@@ -30,32 +24,42 @@ pub struct Compute<'compute> {
     pub longest_lines: Vec<f32>,
 }
 
+/// Configuration for computing.
+pub struct ComputeConfig {
+    /// The height of the observer that views viewsheds.
+    pub observer_height: f32,
+    /// Where to run the kernel computations
+    pub backend: crate::config::Backend,
+    /// What to compute.
+    pub process: Vec<crate::config::Process>,
+    /// The OS's state directory for saving our cache into.
+    pub state_directory: Option<std::path::PathBuf>,
+    /// Output directory
+    pub output_directory: Option<std::path::PathBuf>,
+    /// The number of reserved rings per km.
+    pub rings_per_km: f32,
+    /// How to normalise the heatmap data.
+    pub heatmap: crate::config::HeatmapNormalisation,
+}
+
 impl<'compute> Compute<'compute> {
     /// Instantiate.
-    pub fn new(
-        backend: crate::config::Backend,
-        process: Vec<crate::config::Process>,
-        state_directory: Option<std::path::PathBuf>,
-        maybe_output_directory: Option<std::path::PathBuf>,
-        dem: &'compute mut crate::dem::DEM,
-        rings_per_km: f32,
-        observer_height: f32,
-    ) -> Result<Self> {
+    pub fn new(config: ComputeConfig, dem: &'compute mut crate::dem::DEM) -> Result<Self> {
         let total_bands = dem.computable_points_count * 2;
 
-        let rings_per_band = if Self::is_process_viewsheds(&process) {
-            Self::ring_count_per_band(rings_per_km, dem.max_line_of_sight)
+        let rings_per_band = if Self::is_process_viewsheds(&config.process) {
+            Self::ring_count_per_band(config.rings_per_km, dem.max_line_of_sight)
         } else {
             1
         };
-        let total_reserved_rings = if Self::is_process_viewsheds(&process) {
+        let total_reserved_rings = if Self::is_process_viewsheds(&config.process) {
             usize::try_from(total_bands)? * rings_per_band
         } else {
             1
         };
 
-        let storage = if Self::is_process_viewsheds(&process) {
-            match &maybe_output_directory {
+        let storage = if Self::is_process_viewsheds(&config.process) {
+            match &config.output_directory {
                 Some(output_directory) => {
                     Some(crate::output::ring_data::Storage::new(output_directory)?)
                 }
@@ -70,9 +74,9 @@ impl<'compute> Compute<'compute> {
             max_los_as_points: dem.max_los_as_points,
             dem_width: dem.width,
             tvs_width: dem.tvs_width,
-            observer_height,
+            observer_height: config.observer_height,
             reserved_rings_per_band: u32::try_from(rings_per_band)?,
-            process: Self::bitmask_flags_for_kernel(&process),
+            process: Self::bitmask_flags_for_kernel(&config.process),
             ..Default::default()
         };
 
@@ -80,7 +84,7 @@ impl<'compute> Compute<'compute> {
             clippy::if_then_some_else_none,
             reason = "The `?` is hard to use in the closure"
         )]
-        let vulkan = if matches!(backend, crate::config::Backend::Vulkan) {
+        let vulkan = if matches!(config.backend, crate::config::Backend::Vulkan) {
             let elevations = dem.elevations.clone();
             dem.elevations = Vec::new(); // Free up some RAM.
             Some(super::vulkan::Vulkan::new(
@@ -95,11 +99,8 @@ impl<'compute> Compute<'compute> {
         };
 
         Ok(Self {
-            backend,
-            process,
+            config,
             vulkan,
-            state_directory,
-            output_directory: maybe_output_directory,
             storage,
             dem,
             constants,
@@ -169,7 +170,7 @@ impl<'compute> Compute<'compute> {
 
     /// Do all computations.
     pub fn run(&mut self) -> Result<()> {
-        let mut sector_surfaces = if Self::is_process_surfaces(&self.process) {
+        let mut sector_surfaces = if Self::is_process_surfaces(&self.config.process) {
             let blank = vec![0.0; usize::try_from(self.dem.computable_points_count)?];
             self.total_surfaces.clone_from(&blank);
             blank
@@ -177,11 +178,13 @@ impl<'compute> Compute<'compute> {
             Vec::new()
         };
 
-        if Self::is_process_viewsheds(&self.process) && self.output_directory.is_some() {
+        if Self::is_process_viewsheds(&self.config.process)
+            && self.config.output_directory.is_some()
+        {
             self.save_ring_metadata()?;
         }
 
-        let mut longest_lines = if Self::is_process_longest_lines(&self.process) {
+        let mut longest_lines = if Self::is_process_longest_lines(&self.config.process) {
             let blank = vec![0.0; usize::try_from(self.dem.computable_points_count)?];
             self.longest_lines.clone_from(&blank);
             blank
@@ -199,8 +202,8 @@ impl<'compute> Compute<'compute> {
                 &mut longest_lines,
             )?;
 
-            if Self::is_process_viewsheds(&self.process) {
-                match &self.output_directory {
+            if Self::is_process_viewsheds(&self.config.process) {
+                match &self.config.output_directory {
                     Some(_) => {
                         self.save_sector_ring_data(angle, &sector_ring_data)?;
                     }
@@ -208,12 +211,12 @@ impl<'compute> Compute<'compute> {
                 }
             }
 
-            if Self::is_process_surfaces(&self.process) {
+            if Self::is_process_surfaces(&self.config.process) {
                 self.add_sector_surfaces_to_running_total(&sector_surfaces);
                 self.render_total_surfaces()?;
             }
 
-            if Self::is_process_longest_lines(&self.process) {
+            if Self::is_process_longest_lines(&self.config.process) {
                 self.increment_longest_lines(&longest_lines);
                 self.render_longest_lines()?;
             }
@@ -224,7 +227,7 @@ impl<'compute> Compute<'compute> {
 
     /// Either load cache from the filesystem or create and save it.
     fn load_or_compute_cache(&mut self, angle: u16) -> Result<()> {
-        let maybe_cache = if let Some(state_directory) = self.state_directory.clone() {
+        let maybe_cache = if let Some(state_directory) = self.config.state_directory.clone() {
             Some(crate::cache::Cache::new(
                 &state_directory,
                 self.dem.width,
@@ -323,7 +326,7 @@ impl<'compute> Compute<'compute> {
     /// Render a heatmap and `.bt` file of the total surface areas for each point within the computable area of the
     /// DEM.
     fn render_total_surfaces(&self) -> Result<()> {
-        let Some(output_dir) = &self.output_directory else {
+        let Some(output_dir) = &self.config.output_directory else {
             return Ok(());
         };
 
@@ -332,6 +335,7 @@ impl<'compute> Compute<'compute> {
             self.dem.tvs_width,
             self.dem.tvs_width,
             output_dir.join("total_surfaces.png"),
+            self.config.heatmap,
         )?;
 
         crate::output::bt::save(
@@ -346,7 +350,7 @@ impl<'compute> Compute<'compute> {
     /// Render a heatmap and `.bt` of the longest lines of sight for each point within the computable area of the
     /// DEM.
     fn render_longest_lines(&self) -> Result<()> {
-        let Some(output_dir) = &self.output_directory else {
+        let Some(output_dir) = &self.config.output_directory else {
             return Ok(());
         };
 
@@ -355,6 +359,7 @@ impl<'compute> Compute<'compute> {
             self.dem.tvs_width,
             self.dem.tvs_width,
             output_dir.join("longest_lines.png"),
+            self.config.heatmap,
         )?;
 
         crate::output::bt::save(
@@ -375,7 +380,7 @@ impl<'compute> Compute<'compute> {
         longest_lines: &mut [f32],
     ) -> Result<()> {
         tracing::info!("Running kernel for {angle}°");
-        match self.backend {
+        match self.config.backend {
             crate::config::Backend::CPU => {
                 self.compute_sector_cpu(cumulative_surfaces, ring_data, longest_lines);
             }
@@ -403,13 +408,13 @@ impl<'compute> Compute<'compute> {
 
         let (surfaces_data, rings_data, longest_lines_data) =
             gpu.run(&self.dem.band_distances, &self.dem.band_deltas)?;
-        if Self::is_process_surfaces(&self.process) {
+        if Self::is_process_surfaces(&self.config.process) {
             cumulative_surfaces.copy_from_slice(surfaces_data.as_slice());
         }
-        if Self::is_process_viewsheds(&self.process) {
+        if Self::is_process_viewsheds(&self.config.process) {
             rings.copy_from_slice(rings_data.as_slice());
         }
-        if Self::is_process_longest_lines(&self.process) {
+        if Self::is_process_longest_lines(&self.config.process) {
             longest_lines.copy_from_slice(longest_lines_data.as_slice());
         }
         Ok(())
@@ -452,20 +457,21 @@ pub mod test {
     }
 
     pub fn compute<'dem>(dem: &'dem mut crate::dem::DEM, elevations: &[i16]) -> Compute<'dem> {
-        dem.elevations = elevations.iter().map(|&x| f32::from(x)).collect();
-        let mut compute = Compute::new(
-            crate::config::Backend::CPU,
-            vec![
+        let config = ComputeConfig {
+            observer_height: 1.8,
+            backend: crate::config::Backend::CPU,
+            process: vec![
                 crate::config::Process::TotalSurfaces,
                 crate::config::Process::Viewsheds,
             ],
-            None,
-            None,
-            dem,
-            5000.0,
-            1.8,
-        )
-        .unwrap();
+            state_directory: None,
+            output_directory: None,
+            rings_per_km: 5000.0,
+            heatmap: crate::config::HeatmapNormalisation::UnitScale,
+        };
+        dem.elevations = elevations.iter().map(|&x| f32::from(x)).collect();
+
+        let mut compute = Compute::new(config, dem).unwrap();
         compute.run().unwrap();
         compute
     }

--- a/crates/total-viewsheds/src/config.rs
+++ b/crates/total-viewsheds/src/config.rs
@@ -94,6 +94,15 @@ pub struct Compute {
     /// The input DEM file. Currently only `.hgt` files are supported.
     #[arg(value_name = "Path to the DEM file")]
     pub input: std::path::PathBuf,
+
+    /// How to normalise heatmap data
+    #[arg(
+        long,
+        value_enum,
+        value_name = "Heatmap normalisation method",
+        default_value_t = HeatmapNormalisation::UnitScale
+    )]
+    pub heatmap: HeatmapNormalisation,
 }
 
 #[derive(clap::Parser, Debug)]
@@ -149,4 +158,17 @@ pub enum Process {
     Viewsheds,
     /// Compute the longest line of sight for each DEM point.
     LongestLines,
+}
+
+/// Where to run the computations.
+#[derive(clap::ValueEnum, Clone, Debug, Copy)]
+pub enum HeatmapNormalisation {
+    /// Just scale between 0 and 1
+    UnitScale,
+    #[expect(clippy::doc_markdown, reason = "This is displayed on the CLI")]
+    /// Use Z-score normalisation based on Welford's algorithm. This basically means that the
+    /// data is redistributed such that the mean is 0.5. Useful for overly dark or bright
+    /// heatmaps.
+    /// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+    Welford,
 }

--- a/crates/total-viewsheds/src/main.rs
+++ b/crates/total-viewsheds/src/main.rs
@@ -114,15 +114,16 @@ fn compute(config: &config::Compute) -> Result<()> {
     tracing::debug!("Created DEM: {dem:?}");
 
     tracing::info!("Starting computations");
-    let mut compute = crate::compute::Compute::new(
-        config.backend.clone(),
-        config.process.clone(),
-        Some(dirs::state_dir().context("Couldn't get the OS's state directory")?),
-        Some(config.output_dir.clone()),
-        &mut dem,
-        config.rings_per_km,
-        config.observer_height,
-    )?;
+    let compute_config = compute::ComputeConfig {
+        observer_height: config.observer_height,
+        backend: config.backend.clone(),
+        process: config.process.clone(),
+        state_directory: Some(dirs::state_dir().context("Couldn't get the OS's state directory")?),
+        output_directory: Some(config.output_dir.clone()),
+        rings_per_km: config.rings_per_km,
+        heatmap: config.heatmap,
+    };
+    let mut compute = crate::compute::Compute::new(compute_config, &mut dem)?;
     compute.run()?;
     Ok(())
 }

--- a/crates/total-viewsheds/src/output/png.rs
+++ b/crates/total-viewsheds/src/output/png.rs
@@ -2,19 +2,23 @@
 use color_eyre::{eyre::ContextCompat as _, Result};
 
 /// Convert an array of floats to a grayscale heatmap.
-pub fn save(data: &[f32], width: u32, height: u32, path: std::path::PathBuf) -> Result<()> {
+pub fn save(
+    data: &[f32],
+    width: u32,
+    height: u32,
+    path: std::path::PathBuf,
+    normalisation: crate::config::HeatmapNormalisation,
+) -> Result<()> {
     tracing::info!("Writing PNG data to: {}", path.display());
-    let (min, max) = data
-        .iter()
-        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &value| {
-            (min.min(value), max.max(value))
-        });
-    let range = if max - min == 0.0 { 1.0 } else { max - min };
 
-    let pixels: Vec<u8> = data
+    let data_normalised = match normalisation {
+        crate::config::HeatmapNormalisation::UnitScale => normalise(data),
+        crate::config::HeatmapNormalisation::Welford => welford_normalise(data),
+    };
+
+    let pixels: Vec<u8> = data_normalised
         .iter()
         .map(|&value| {
-            let normalised = ((value - min) / range * 255.0).clamp(0.0, 255.0);
             #[expect(
                 clippy::as_conversions,
                 clippy::cast_possible_truncation,
@@ -22,7 +26,7 @@ pub fn save(data: &[f32], width: u32, height: u32, path: std::path::PathBuf) -> 
                 reason = "We've already guaranteed all the values are within the correct range"
             )]
             {
-                normalised as u8
+                (value * 255.0) as u8
             }
         })
         .collect();
@@ -40,4 +44,95 @@ pub fn save(data: &[f32], width: u32, height: u32, path: std::path::PathBuf) -> 
     png.save(path)?;
 
     Ok(())
+}
+
+/// Scale values from 0 to 1.
+fn normalise(data: &[f32]) -> Vec<f32> {
+    let min = data.iter().copied().fold(f32::INFINITY, f32::min);
+    let max = data.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    data.iter().map(|&x| (x - min) / (max - min)).collect()
+}
+
+/// Redistribute values from 0 to 1 such that the distribution is centered.
+/// This might help with heatmaps that are overly dark or bright.
+///
+/// GPT-5 helped with this.
+fn welford_normalise(data: &[f32]) -> Vec<f32> {
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "It's just a vector length"
+    )]
+    let total = data.len() as f32;
+
+    // Compute mean and population variance using Welford's algorithm.
+    // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+    let mut mean = 0.0;
+    let mut m2 = 0.0;
+    for (index, &value) in data.iter().enumerate() {
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "Just incrementing by 1"
+        )]
+        let count = index as f32 + 1.0;
+        let delta = value - mean;
+        mean += delta / count;
+        let delta2 = value - mean;
+        m2 += delta * delta2;
+    }
+    let variance = m2 / total;
+    let standard_deviation = variance.sqrt().max(f32::EPSILON);
+
+    let z_score: Vec<f32> = data
+        .iter()
+        .map(|&x| (x - mean) / standard_deviation)
+        .collect();
+
+    let (mut min_zscore, mut max_zscore) = (f32::INFINITY, f32::NEG_INFINITY);
+    for &candidate in &z_score {
+        if candidate < min_zscore {
+            min_zscore = candidate;
+        }
+        if candidate > max_zscore {
+            max_zscore = candidate;
+        }
+    }
+
+    // Scale from 0 to 1.
+    let mut scaled: Vec<f32> = z_score
+        .iter()
+        .map(|&z| (z - min_zscore) / (max_zscore - min_zscore))
+        .collect();
+
+    // Enforce mean to be 0.5
+    let mean_scaled = scaled.iter().sum::<f32>() / total;
+    let shift = 0.5 - mean_scaled;
+    for value in &mut scaled {
+        *value = (*value + shift).clamp(0.0, 1.0);
+    }
+
+    // If the previous clampings overly changed the mean, then adjust proportionally.
+    let final_mean = scaled.iter().sum::<f32>() / total;
+    if (final_mean - 0.5).abs() > f32::EPSILON {
+        let diff = 0.5 - final_mean;
+        for value in &mut scaled {
+            *value = (*value + diff).clamp(0.0, 1.0);
+        }
+    }
+
+    scaled
+}
+
+#[expect(clippy::unreadable_literal, reason = "These are just tests")]
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn welford_normalisation() {
+        let values = vec![1.0, 120.2, 40.9, 91.0];
+        let normalised = welford_normalise(&values);
+        assert_eq!(normalised, vec![0.0, 0.9719484, 0.30667996, 0.726982]);
+    }
 }


### PR DESCRIPTION
Helps with overly dark or light heatmaps.

Before:
<img width="334" height="334" alt="total_surfaces" src="https://github.com/user-attachments/assets/907958e0-0864-418d-9ade-95a6eaa88fb8" />

After:
<img width="334" height="334" alt="total_surfaces" src="https://github.com/user-attachments/assets/93ff8ccd-133b-4bca-9bb1-74ebaa7791b4" />

Use with `--heatmap welford`.