### PR TITLE
feat: Ignore points outside user-defined polygon 

### DIFF
--- a/crates/total-viewsheds/src/config.rs
+++ b/crates/total-viewsheds/src/config.rs
@@ -130,8 +130,19 @@ pub struct Compute {
         default_value = "./viewsheds.db"
     )]
     pub viewsheds_db_path: PathBuf,
+
+    /// Lon/lat coordinates for a polygon that represents an Area of Interest within the DEM.
+    /// Points outside this polygon will be ignored.
+    #[arg(
+        long,
+        allow_hyphen_values(true),
+        value_parser = parse_coords,
+        value_name = "Lon/lat coords of region")
+    ]
+    pub aoi_point: Vec<(f32, f32)>,
 }
 
+/// Arguments to the `viewshed` subcommand.
 #[derive(clap::Parser, Debug)]
 pub struct Viewshed {
     /// Path or directory where viewshed DB was saved.
@@ -147,6 +158,7 @@ pub struct Viewshed {
     pub coordinates: Vec<(f32, f32)>,
 }
 
+/// Parse args like "123.456,-987.654" to floats.
 fn parse_coords(string: &str) -> Result<(f32, f32)> {
     let mut coordinates = Vec::new();
 

--- a/crates/total-viewsheds/src/cpu/area_of_interest.rs
+++ b/crates/total-viewsheds/src/cpu/area_of_interest.rs
@@ -1,0 +1,98 @@
+//! Determine whether a given point in a DEM needs to have viewsheds computed for it.
+
+use color_eyre::Result;
+
+use geo::Contains as _;
+
+/// `Pruner`
+pub struct Pruner {
+    /// Width of the DEM in points
+    width: u32,
+    /// The DEM coordinates for the Area of Interest.
+    polygon: geo::Polygon,
+}
+
+impl Pruner {
+    /// Instantiate.
+    pub const fn new(width: u32, polygon: geo::Polygon) -> Self {
+        Self { width, polygon }
+    }
+
+    /// Convert user-provided lon/lat coordinates to a polygon.
+    pub fn lonlat_coords_to_polygon(
+        points: Vec<(f32, f32)>,
+        metadata: &super::storage::metadata::MetaData,
+    ) -> Result<geo::Polygon> {
+        let mut vertices = Vec::new();
+
+        for intrest_point in points {
+            let lonlat = crate::projection::LonLatCoord(
+                geo::coord!(x: intrest_point.0.into(), y: intrest_point.1.into()),
+            );
+            let dem_coord = crate::projection::Converter::lonlat_to_dem_coord(metadata, lonlat)?;
+            let dem_point = geo::point!(x: dem_coord.0.x, y: dem_coord.0.y);
+            vertices.push(dem_point);
+        }
+
+        let exterior = geo::LineString::from(vertices);
+        let polygon = geo::Polygon::new(exterior, vec![]);
+
+        Ok(polygon)
+    }
+
+    /// Can the given DEM ID be ignored in computations.
+    pub fn is_prunable(&self, dem_id: i64) -> bool {
+        let dem_coord = self.convert_dem_id_to_coord(dem_id);
+        !self.polygon.contains(&dem_coord.0)
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "We're only dealing with a max of the DEM's width"
+    )]
+    /// Convert a DEM 1D index to a 2D coordinate.
+    pub fn convert_dem_id_to_coord(&self, dem_id: i64) -> crate::dem::Coordinate {
+        let x = dem_id.rem_euclid(self.width.into()) as f64;
+        let y = dem_id.div_euclid(self.width.into()) as f64;
+        crate::dem::Coordinate(geo::coord! {x: x, y: y})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pruner() -> Pruner {
+        let width = 300;
+        let metadata = crate::cpu::storage::metadata::MetaData {
+            width,
+            scale: 100.0,
+            centre: crate::projection::LonLatCoord((-3.1791, 51.4816).into()),
+            ..Default::default()
+        };
+        let cardiff_10km = vec![
+            (-3.2511, 51.4366),
+            (-3.1071, 51.4366),
+            (-3.1071, 51.5266),
+            (-3.2511, 51.5266),
+            (-3.2511, 51.4366),
+        ];
+        let polygon = Pruner::lonlat_coords_to_polygon(cardiff_10km, &metadata).unwrap();
+        Pruner::new(width, polygon)
+    }
+
+    #[test]
+    fn is_pruned_outside_polygon() {
+        let pruner = make_pruner();
+        assert!(pruner.is_prunable(0));
+    }
+
+    #[test]
+    fn is_not_pruned_inside_polygon() {
+        let pruner = make_pruner();
+        // Why the extra 150 to get to the centre??
+        let dem_id = (300i64.pow(2) / 2) + 150;
+        assert!(!pruner.is_prunable(dem_id));
+    }
+}

--- a/crates/total-viewsheds/src/cpu/kernel.rs
+++ b/crates/total-viewsheds/src/cpu/kernel.rs
@@ -1,9 +1,9 @@
 use crate::cpu::los::LineOfSight as _;
+use crate::cpu::rotation::lines;
 use crate::cpu::unrolled_los::UnrolledVectorLos;
 use crate::cpu::vector_intrinsics::DEFAULT_VECTOR_LENGTH;
 use crate::los_pack::LineOfSightPacked;
 use itertools::izip;
-use crate::cpu::rotation::lines;
 
 /// The data output by a single angle.
 pub struct OutputData {
@@ -54,40 +54,52 @@ const DEFAULT_UNROLL: usize = const {
     }
 };
 
-
-
 /// `kernel` will calculate the longest line of sight heatmap for a given angle and elevation map
 /// assuming that the maximum line of sight is `max_los`
 pub fn kernel(
     db_worker: &super::storage::worker::Worker,
     elevation_map: &[i16],
     output: &mut OutputData,
-    max_los: usize,
     angle: f32,
     config: &crate::run::compute::Config,
 ) {
+    #[expect(clippy::expect_used, reason = "We need to panic on failure")]
+    let max_los = usize::try_from(config.metadata.max_line_of_sight)
+        .expect("Line of sight length doesn't fit into `usize`");
     let surfaces = &mut output.surfaces;
     let longest = &mut output.longest;
 
     assert_eq!(
-         surfaces.len(),
-         max_los * max_los,
-         "surfaces should be max_los squared length"
+        surfaces.len(),
+        max_los * max_los,
+        "surfaces should be max_los squared length"
     );
 
     assert_eq!(
         longest.len(),
-        max_los*max_los,
+        max_los * max_los,
         "longest lines should be max_los squared length"
     );
 
-    let mut vs =
-        UnrolledVectorLos::<DEFAULT_UNROLL, DEFAULT_VECTOR_LENGTH>::new(max_los, config.refraction, config.scale);
+    let mut vs = UnrolledVectorLos::<DEFAULT_UNROLL, DEFAULT_VECTOR_LENGTH>::new(
+        max_los,
+        config.refraction,
+        config.scale,
+    );
+
+    let pruner = super::area_of_interest::Pruner::new(
+        config.metadata.width,
+        config.area_of_interest.clone(),
+    );
 
     for (line, line_indexes) in lines(elevation_map, max_los, angle.into()) {
         for (pov, (&pov_height, &result_dem_id)) in
             izip!(line.iter().take(max_los), line_indexes.iter().take(max_los)).enumerate()
         {
+            if pruner.is_prunable(result_dem_id) {
+                continue;
+            }
+
             let result_tvs_id = dem_id_to_tvs_id(result_dem_id, 3 * max_los, max_los);
 
             // if the line of sight is not within our computable points, do not consider it
@@ -125,7 +137,10 @@ pub fn kernel(
                 // safety: result_tvs_id is guaranteed to be within [0..max_los^2)
                 unsafe {
                     let longest_ptr = longest.get_unchecked_mut(result_tvs_id as usize);
-                    *longest_ptr = longest_ptr.max(LineOfSightPacked::new_unchecked(point_longest as u32, angle as u16));
+                    *longest_ptr = longest_ptr.max(LineOfSightPacked::new_unchecked(
+                        point_longest as u32,
+                        angle as u16,
+                    ));
                 };
                 if cfg!(any(test, feature = "ring_data"))
                     && crate::run::compute::Compute::is_process_viewsheds(&config.process)
@@ -139,31 +154,44 @@ pub fn kernel(
 
 #[cfg(test)]
 mod test {
-    use crate::{cpu::kernel as cpu_kernel, los_pack::LineOfSightPacked, run::compute::test::default_config};
     use crate::cpu::kernel::OutputData;
+    use crate::{
+        cpu::kernel as cpu_kernel, los_pack::LineOfSightPacked, run::compute::test::default_config,
+    };
 
     #[test]
     fn total_surfaces() {
         let dem = &kernel::tests::dems::bigger_dem();
         let db_worker = crate::cpu::storage::worker::Worker::new_noop();
-        let config = default_config(
-            crate::config::Backend::CPU,
-            &tempfile::NamedTempFile::new().unwrap(),
-        );
+        let width = 4;
+        let metadata = crate::cpu::storage::metadata::MetaData {
+            width,
+            scale: 1.0,
+            max_line_of_sight: width,
+            reserved_ring_size: 0,
+            centre: crate::projection::LonLatCoord((0.0, 0.0).into()),
+        };
+        let config = crate::run::compute::Config {
+            metadata,
+            ..default_config(
+                crate::config::Backend::CPU,
+                &tempfile::NamedTempFile::new().unwrap(),
+            )
+        };
 
         let mut forward = OutputData {
-            surfaces: vec![0.0f32; 4*4],
-            longest: vec![LineOfSightPacked::new(0, 0).unwrap(); 4 * 4]
+            surfaces: vec![0.0f32; 4 * 4],
+            longest: vec![LineOfSightPacked::new(0, 0).unwrap(); 4 * 4],
         };
 
-        cpu_kernel(&db_worker, dem, &mut forward, 4, 0.0, &config);
+        cpu_kernel(&db_worker, dem, &mut forward, 0.0, &config);
 
         let mut backward = OutputData {
-            surfaces: vec![0.0f32; 4*4],
-            longest: vec![LineOfSightPacked::new(0, 0).unwrap(); 4 * 4]
+            surfaces: vec![0.0f32; 4 * 4],
+            longest: vec![LineOfSightPacked::new(0, 0).unwrap(); 4 * 4],
         };
 
-        cpu_kernel(&db_worker, dem, &mut backward, 4, 180.0, &config);
+        cpu_kernel(&db_worker, dem, &mut backward, 180.0, &config);
 
         let result = forward
             .surfaces

--- a/crates/total-viewsheds/src/cpu/storage/metadata.rs
+++ b/crates/total-viewsheds/src/cpu/storage/metadata.rs
@@ -16,5 +16,5 @@ pub struct MetaData {
     pub reserved_ring_size: usize,
     /// The lat/lon coordinates for the centre of the 2D DEM grid. Used for accurately converting
     /// between degree and metric coordinate systems.
-    pub centre: crate::projection::LatLonCoord,
+    pub centre: crate::projection::LonLatCoord,
 }

--- a/crates/total-viewsheds/src/cpu/storage/metadata.rs
+++ b/crates/total-viewsheds/src/cpu/storage/metadata.rs
@@ -8,9 +8,7 @@ pub struct MetaData {
     pub width: u32,
     /// The diameter in meters each point of the data covers.
     pub scale: f32,
-    /// The maximum line of sight (in meters) that was used to calculate the ring data. It is needed
-    /// to instantiate the `DEM` struct and therefore reconstruct the bands of sight used to create
-    /// the ring data.
+    /// The maximum line of sight (in points). Unit is metres for Vulkan, to be deprecated soon.
     pub max_line_of_sight: u32,
     /// The number of items reserved to place ring DEM IDs in.
     pub reserved_ring_size: usize,

--- a/crates/total-viewsheds/src/dem.rs
+++ b/crates/total-viewsheds/src/dem.rs
@@ -133,26 +133,6 @@ impl DEM {
             (yish + x) as u32
         }
     }
-
-    /// Convert a lat/lon to a DEM coordinate.
-    pub fn latlon_to_dem_coord(
-        &self,
-        latlon: crate::projection::LonLatCoord,
-    ) -> Result<crate::dem::Coordinate> {
-        let width = f64::from(self.width - 1);
-        let scale = f64::from(self.scale);
-        let coord_metric = crate::projection::Converter { base: self.centre }.to_meters(latlon)?;
-        let offset = (width * scale) / 2.0f64;
-        let dem_coord = crate::dem::Coordinate(
-            geo::coord! {
-                x: coord_metric.x + offset,
-                // Invert the y coordinate because geographic coordinates are anchored to the bottom left
-                // and DEM coordinates are anchored to the top right.
-                y: -coord_metric.y + offset
-            } / scale,
-        );
-        Ok(dem_coord)
-    }
 }
 
 /// Serialise for Debugging.
@@ -171,21 +151,5 @@ impl std::fmt::Debug for DEM {
             .field("max_los_as_points", &self.max_los_as_points)
             .field("computable_points_count", &self.computable_points_count)
             .finish()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn latlon_to_dem_coord() {
-        let centre = crate::projection::LonLatCoord((-33.33f64, 12.34f64).into());
-        let dem = DEM::new(centre, 102, 5.0, 250).unwrap();
-
-        assert_eq!(
-            dem.latlon_to_dem_coord(centre).unwrap(),
-            Coordinate((50.5f64, 50.5f64).into())
-        );
     }
 }

--- a/crates/total-viewsheds/src/dem.rs
+++ b/crates/total-viewsheds/src/dem.rs
@@ -30,7 +30,7 @@ pub struct DEM {
     /// The size of each point in meters.
     pub scale: f32,
     /// The geographic location of the centre of the DEM tile.
-    pub centre: crate::projection::LatLonCoord,
+    pub centre: crate::projection::LonLatCoord,
     /// The maximum distance in terms of points to search.
     pub max_los_as_points: u32,
     /// The total number of points that can have full viewsheds calculated for them.
@@ -40,7 +40,7 @@ pub struct DEM {
 impl DEM {
     /// `Instantiate`
     pub fn new(
-        centre_latlon: crate::projection::LatLonCoord,
+        centre_latlon: crate::projection::LonLatCoord,
         width: u32,
         scale: f32,
         max_line_of_sight: u32,
@@ -137,7 +137,7 @@ impl DEM {
     /// Convert a lat/lon to a DEM coordinate.
     pub fn latlon_to_dem_coord(
         &self,
-        latlon: crate::projection::LatLonCoord,
+        latlon: crate::projection::LonLatCoord,
     ) -> Result<crate::dem::Coordinate> {
         let width = f64::from(self.width - 1);
         let scale = f64::from(self.scale);
@@ -180,7 +180,7 @@ mod test {
 
     #[test]
     fn latlon_to_dem_coord() {
-        let centre = crate::projection::LatLonCoord((-33.33f64, 12.34f64).into());
+        let centre = crate::projection::LonLatCoord((-33.33f64, 12.34f64).into());
         let dem = DEM::new(centre, 102, 5.0, 250).unwrap();
 
         assert_eq!(

--- a/crates/total-viewsheds/src/main.rs
+++ b/crates/total-viewsheds/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
         config::Commands::Compute(compute_config) => compute(compute_config)?,
         config::Commands::Viewshed(viewshed_config) => {
             for coordinate in &viewshed_config.coordinates {
-                let geo_coord = projection::LatLonCoord(
+                let geo_coord = projection::LonLatCoord(
                     geo::coord! {x: f64::from(coordinate.0), y: f64::from(coordinate.1)},
                 );
 

--- a/crates/total-viewsheds/src/main.rs
+++ b/crates/total-viewsheds/src/main.rs
@@ -23,9 +23,9 @@
 
 extern crate core;
 
-use std::mem;
 use clap::Parser as _;
 use color_eyre::eyre::Result;
+use std::mem;
 use tracing_subscriber::{Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 /// Handling the running of computations.
@@ -37,6 +37,8 @@ mod run {
 mod config;
 /// cpu implements a CPU kernel for the longest line of sight
 mod cpu {
+    pub mod area_of_interest;
+
     /// los contains all the traits necessary for implementing a line of sight algorithm
     mod los;
 
@@ -142,9 +144,9 @@ fn compute(config: &config::Compute) -> Result<()> {
         clippy::cast_precision_loss,
         reason = "Sign loss and truncation aren't relevant"
     )]
-    let max_line_of_sight = (tile.width.div_euclid(3) as f32 * scale) as u32;
+    let max_line_of_sight_metres = (tile.width.div_euclid(3) as f32 * scale) as u32;
 
-    let mut dem = crate::dem::DEM::new(tile.centre, tile.width, scale, max_line_of_sight)?;
+    let mut dem = crate::dem::DEM::new(tile.centre, tile.width, scale, max_line_of_sight_metres)?;
 
     dem.elevations = mem::take(&mut tile.data);
 
@@ -153,6 +155,23 @@ fn compute(config: &config::Compute) -> Result<()> {
 
     tracing::debug!("Created DEM: {dem:?}");
 
+    let max_line_of_sight = if matches!(config.backend, config::Backend::CPU) {
+        dem.max_los_as_points
+    } else {
+        max_line_of_sight_metres
+    };
+
+    let metadata = crate::cpu::storage::metadata::MetaData {
+        width: dem.width,
+        scale: dem.scale,
+        max_line_of_sight,
+        reserved_ring_size: run::compute::Compute::ring_count_per_band(
+            config.rings_per_km,
+            dem.max_los_as_points * dem.scale_u32(),
+        ),
+        centre: dem.centre,
+    };
+
     tracing::info!("Starting computations");
     let compute_config = run::compute::Config {
         observer_height: config.observer_height,
@@ -160,12 +179,16 @@ fn compute(config: &config::Compute) -> Result<()> {
         backend: config.backend.clone(),
         process: config.process.clone(),
         output_directory: Some(config.output_dir.clone()),
-        rings_per_km: config.rings_per_km,
         heatmap: config.heatmap,
         refraction: config.refraction,
         thread_count: config.thread_count,
         disable_render_image: config.disable_image_render,
         viewsheds_db_path: config.viewsheds_db_path.clone(),
+        area_of_interest: crate::cpu::area_of_interest::Pruner::lonlat_coords_to_polygon(
+            config.aoi_point.clone(),
+            &metadata,
+        )?,
+        metadata,
     };
 
     let mut compute = run::compute::Compute::new(compute_config, &mut dem)?;

--- a/crates/total-viewsheds/src/output/viewshed.rs
+++ b/crates/total-viewsheds/src/output/viewshed.rs
@@ -22,7 +22,7 @@ impl Viewshed<'_> {
     /// Reconstruct a viewshed.
     pub fn reconstruct(
         source: &super::ring_data::Source,
-        pov_coord_latlon: crate::projection::LatLonCoord,
+        pov_coord_latlon: crate::projection::LonLatCoord,
     ) -> Result<geo::MultiPolygon> {
         let ring_data = match source {
             crate::output::ring_data::Source::Directory(directory) => {
@@ -341,7 +341,7 @@ impl<'viewshed> Reconstructor<'viewshed> {
     pub fn save(
         mut viewshed: geo::MultiPolygon,
         output_directory: &std::path::Path,
-        viewshed_latlon: crate::projection::LatLonCoord,
+        viewshed_latlon: crate::projection::LonLatCoord,
     ) -> Result<()> {
         let filename = format!("{}-{}.json", viewshed_latlon.0.x, viewshed_latlon.0.y);
         let directory = output_directory.join("viewsheds");

--- a/crates/total-viewsheds/src/output/viewshed.rs
+++ b/crates/total-viewsheds/src/output/viewshed.rs
@@ -22,7 +22,7 @@ impl Viewshed<'_> {
     /// Reconstruct a viewshed.
     pub fn reconstruct(
         source: &super::ring_data::Source,
-        pov_coord_latlon: crate::projection::LonLatCoord,
+        pov_coord_lonlat: crate::projection::LonLatCoord,
     ) -> Result<geo::MultiPolygon> {
         let ring_data = match source {
             crate::output::ring_data::Source::Directory(directory) => {
@@ -44,7 +44,10 @@ impl Viewshed<'_> {
             ring_data.metadata.max_line_of_sight,
         )?;
 
-        let pov_dem_coord = dem.latlon_to_dem_coord(pov_coord_latlon)?;
+        let pov_dem_coord = crate::projection::Converter::lonlat_to_dem_coord(
+            &ring_data.metadata,
+            pov_coord_lonlat,
+        )?;
         tracing::info!(
             "Reconstructing viewshed for DEM-relative coord: {:?}.",
             pov_dem_coord

--- a/crates/total-viewsheds/src/projection.rs
+++ b/crates/total-viewsheds/src/projection.rs
@@ -5,12 +5,12 @@ use color_eyre::Result;
 // TODO: Rename to `LonLatCoord`.
 /// A latitude/longtitude coordinate.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Default)]
-pub struct LatLonCoord(pub geo::Coord);
+pub struct LonLatCoord(pub geo::Coord);
 
 /// Convert between different coordinate system.
 pub struct Converter {
     /// The lat/lon base coordinates for the AEQD mercator projected coordinates.
-    pub base: LatLonCoord,
+    pub base: LonLatCoord,
 }
 
 impl Converter {
@@ -30,7 +30,7 @@ impl Converter {
     }
 
     /// Convert from degrees to the AEQD metric projection.
-    pub fn to_meters(&self, source: LatLonCoord) -> Result<geo::Coord> {
+    pub fn to_meters(&self, source: LonLatCoord) -> Result<geo::Coord> {
         let mut converted = (source.0.x.to_radians(), source.0.y.to_radians(), 0.0f64);
         proj4rs::transform::transform(
             &Self::degrees_projection()?,
@@ -42,7 +42,7 @@ impl Converter {
     }
 
     /// Convert from the AEQD metric projection to degrees.
-    pub fn to_degrees(&self, source: geo::Coord) -> Result<LatLonCoord> {
+    pub fn to_degrees(&self, source: geo::Coord) -> Result<LonLatCoord> {
         let mut converted = (source.x, source.y, 0.0f64);
         proj4rs::transform::transform(
             &self.meters_projection()?,
@@ -50,7 +50,7 @@ impl Converter {
             &mut converted,
         )?;
 
-        Ok(LatLonCoord(
+        Ok(LonLatCoord(
             geo::coord! { x: converted.0.to_degrees(), y: converted.1.to_degrees() },
         ))
     }
@@ -60,7 +60,7 @@ impl Converter {
     /// reconstructing larger viewsheds on larger DEMs.
     pub fn change_metric_origin(
         // The lat/lon of the DEM's top-left corner
-        source_degrees_anchor: LatLonCoord,
+        source_degrees_anchor: LonLatCoord,
         // The AEQD coordinates of a viewshed's centre.
         target_metric_anchor: geo::Coord,
         // The point in the viewshed, in metric coordinates, to be converted.
@@ -99,7 +99,7 @@ mod test {
 
     #[test]
     fn bristol_to_meters() {
-        let base = LatLonCoord(geo::Coord {
+        let base = LonLatCoord(geo::Coord {
             x: -2.5879,
             y: 51.4545,
         });
@@ -112,14 +112,14 @@ mod test {
 
     #[test]
     fn bristolish_to_meters() {
-        let base = LatLonCoord(geo::Coord {
+        let base = LonLatCoord(geo::Coord {
             x: -2.5879,
             y: 51.4545,
         });
         let converter = Converter { base };
         assert_eq!(
             converter
-                .to_meters(LatLonCoord(geo::Coord {
+                .to_meters(LonLatCoord(geo::Coord {
                     x: -2.573510680530247,
                     y: 51.463487311585936
                 }))
@@ -133,14 +133,14 @@ mod test {
 
     #[test]
     fn bristol_to_degrees() {
-        let base = LatLonCoord(geo::Coord {
+        let base = LonLatCoord(geo::Coord {
             x: -2.5879,
             y: 51.4545,
         });
         let converter = Converter { base };
         assert_eq!(
             converter.to_degrees(geo::Coord { x: 0.0, y: 0.0 }).unwrap(),
-            LatLonCoord(geo::Coord {
+            LonLatCoord(geo::Coord {
                 x: -2.5879,
                 y: 51.45450000000001
             })
@@ -149,7 +149,7 @@ mod test {
 
     #[test]
     fn bristolish_to_degrees() {
-        let base = LatLonCoord(geo::Coord {
+        let base = LonLatCoord(geo::Coord {
             x: -2.5879,
             y: 51.4545,
         });
@@ -161,7 +161,7 @@ mod test {
                     y: 1000.0
                 })
                 .unwrap(),
-            LatLonCoord(geo::Coord {
+            LonLatCoord(geo::Coord {
                 x: -2.573510680530247,
                 y: 51.463487311585936
             })

--- a/crates/total-viewsheds/src/projection.rs
+++ b/crates/total-viewsheds/src/projection.rs
@@ -55,6 +55,29 @@ impl Converter {
         ))
     }
 
+    /// Convert a lat/lon to a DEM coordinate.
+    pub fn lonlat_to_dem_coord(
+        metadata: &crate::cpu::storage::metadata::MetaData,
+        latlon: crate::projection::LonLatCoord,
+    ) -> Result<crate::dem::Coordinate> {
+        let width = f64::from(metadata.width - 1);
+        let scale = f64::from(metadata.scale);
+        let coord_metric = Self {
+            base: metadata.centre,
+        }
+        .to_meters(latlon)?;
+        let offset = (width * scale) / 2.0f64;
+        let dem_coord = crate::dem::Coordinate(
+            geo::coord! {
+                x: coord_metric.x + offset,
+                // Invert the y coordinate because geographic coordinates are anchored to the bottom left
+                // and DEM coordinates are anchored to the top right.
+                y: -coord_metric.y + offset
+            } / scale,
+        );
+        Ok(dem_coord)
+    }
+
     #[cfg(test)]
     /// Chante the anchor of the AEQD projection. This just gives slightly more accuracy when
     /// reconstructing larger viewsheds on larger DEMs.
@@ -165,6 +188,23 @@ mod test {
                 x: -2.573510680530247,
                 y: 51.463487311585936
             })
+        );
+    }
+
+    #[test]
+    fn latlon_to_dem_coord() {
+        let centre = crate::projection::LonLatCoord((-33.33f64, 12.34f64).into());
+        let metadata = crate::cpu::storage::metadata::MetaData {
+            width: 102,
+            scale: 5.0,
+            max_line_of_sight: 250,
+            reserved_ring_size: 0,
+            centre,
+        };
+
+        assert_eq!(
+            Converter::lonlat_to_dem_coord(&metadata, centre).unwrap(),
+            crate::dem::Coordinate((50.5f64, 50.5f64).into())
         );
     }
 }

--- a/crates/total-viewsheds/src/run/compute.rs
+++ b/crates/total-viewsheds/src/run/compute.rs
@@ -44,8 +44,6 @@ pub struct Config {
     pub process: Vec<crate::config::Process>,
     /// Output directory
     pub output_directory: Option<std::path::PathBuf>,
-    /// The number of reserved rings per km.
-    pub rings_per_km: f32,
     /// How to normalise the heatmap data.
     pub heatmap: crate::config::HeatmapNormalisation,
     /// Refractoin coefficient
@@ -56,6 +54,11 @@ pub struct Config {
     pub disable_render_image: bool,
     /// Where to store the viewshed
     pub viewsheds_db_path: PathBuf,
+    /// Metadata about the DEM and compute run.
+    // TODO: Remove other fields in favour of this.
+    pub metadata: crate::cpu::storage::metadata::MetaData,
+    /// Polygon for Area of Interest
+    pub area_of_interest: geo::Polygon,
 }
 
 impl<'compute> Compute<'compute> {
@@ -64,7 +67,7 @@ impl<'compute> Compute<'compute> {
         let total_bands = dem.computable_points_count * 2;
 
         let rings_per_band = if Self::is_process_viewsheds(&config.process) {
-            Self::ring_count_per_band(config.rings_per_km, dem.max_los_as_points * dem.scale_u32())
+            config.metadata.reserved_ring_size
         } else {
             1
         };
@@ -318,6 +321,11 @@ pub mod test {
         backend: crate::config::Backend,
         temp_db: &tempfile::NamedTempFile,
     ) -> Config {
+        let metadata = crate::cpu::storage::metadata::MetaData {
+            reserved_ring_size: 100,
+            ..Default::default()
+        };
+
         Config {
             observer_height: 0.8,
             scale: 1.0,
@@ -328,12 +336,13 @@ pub mod test {
                 crate::config::Process::LongestLines,
             ],
             output_directory: None,
-            rings_per_km: 5000.0,
             heatmap: crate::config::HeatmapNormalisation::UnitScale,
             refraction: 0.13f32,
             thread_count: 1, // single thread it for consistency
             disable_render_image: false,
             viewsheds_db_path: temp_db.path().into(),
+            metadata,
+            area_of_interest: geo::Polygon::empty(),
         }
     }
 

--- a/crates/total-viewsheds/src/run/compute.rs
+++ b/crates/total-viewsheds/src/run/compute.rs
@@ -8,7 +8,8 @@ pub const SECTOR_STEPS: u16 = 180;
 
 /// Handles all the computations.
 pub struct Compute<'compute>
-where 'static: 'compute
+where
+    'static: 'compute,
 {
     /// User configuration.
     pub config: Config,
@@ -303,7 +304,7 @@ pub mod test {
     pub fn make_dem(elevations: &[i16]) -> crate::dem::DEM {
         let width = elevations.len().isqrt() as u32;
         let mut dem = crate::dem::DEM::new(
-            crate::projection::LatLonCoord((33.33, 33.33).into()),
+            crate::projection::LonLatCoord((33.33, 33.33).into()),
             width,
             1.0,
             width / 3,

--- a/crates/total-viewsheds/src/run/parallel.rs
+++ b/crates/total-viewsheds/src/run/parallel.rs
@@ -5,9 +5,7 @@ use crate::cpu::{kernel, storage};
 use crate::los_pack::LineOfSightPacked;
 use color_eyre::Result;
 use std::sync::{mpmc, mpsc};
-use std::thread::JoinHandle;
 use std::{thread, time};
-use std::fmt::format;
 
 /// `Work` holds all data needed for a worker to do a line of sight
 /// calculation
@@ -22,11 +20,11 @@ fn kernel_worker(
     work_todo: mpmc::Receiver<Work>,
     res: &mpsc::Sender<OutputData>,
     config: &crate::run::compute::Config,
-    max_los: usize,
 ) {
+    let size = config.metadata.max_line_of_sight.pow(2) as usize;
     let mut output = OutputData {
-        surfaces: vec![0.0f32; max_los * max_los],
-        longest: vec![LineOfSightPacked::new(0, 0).unwrap(); max_los * max_los],
+        surfaces: vec![0.0f32; size],
+        longest: vec![LineOfSightPacked::new(0, 0).unwrap(); size],
     };
 
     for work in work_todo {
@@ -36,7 +34,6 @@ fn kernel_worker(
             storage_worker,
             elevations,
             &mut output,
-            max_los,
             f32::from(work.angle),
             config,
         );
@@ -82,51 +79,33 @@ impl super::compute::Compute<'_> {
         let borrow_elevations = &elevations;
 
         let (out_surfaces, out_longest) = thread::scope(|s| {
-            let worker_handles: Result<Vec<_>> = (0..self.config.thread_count).map(|id| {
-                let db_worker = if Self::is_process_viewsheds(&self.config.process) {
-                    #[expect(
-                        clippy::as_conversions,
-                        clippy::cast_precision_loss,
-                        clippy::cast_sign_loss,
-                        clippy::cast_possible_truncation,
-                        reason = "Should always fit in `u32`"
-                    )]
-                    let max_los_metric =
-                        (self.dem.max_los_as_points as f32 * self.dem.scale) as u32;
+            let worker_handles: Result<Vec<_>> = (0..self.config.thread_count)
+                .map(|id| {
+                    let db_worker = if Self::is_process_viewsheds(&self.config.process) {
+                        let db_path = self.config.viewsheds_db_path.join(format!("{id}.db"));
 
-                    let db_path = self.config
-                        .viewsheds_db_path
-                        .join(format!("{id}.db"));
+                        let db = crate::cpu::storage::db::DB::new(&db_path)?;
+                        db.save_metadata(&config.metadata)?;
 
-                    let db = crate::cpu::storage::db::DB::new(&db_path)?;
-                    db.save_metadata(&crate::cpu::storage::metadata::MetaData {
-                        width: self.dem.width,
-                        scale: self.dem.scale,
-                        max_line_of_sight: max_los_metric,
-                        reserved_ring_size: 0,
-                        centre: self.dem.centre,
-                    })?;
+                        crate::cpu::storage::worker::Worker::new(&db_path)
+                    } else {
+                        crate::cpu::storage::worker::Worker::new_noop()
+                    };
 
-                    crate::cpu::storage::worker::Worker::new(&db_path)
-                } else {
-                    crate::cpu::storage::worker::Worker::new_noop()
-                };
+                    let kernel_send = kernel_send.clone();
+                    let kernel_receive = kernel_receive.clone();
 
-                let kernel_send = kernel_send.clone();
-                let kernel_receive = kernel_receive.clone();
-
-                Ok(s.spawn(move || {
-                    kernel_worker(
-                        &db_worker,
-                        borrow_elevations,
-                        kernel_receive,
-                        &kernel_send,
-                        config,
-                        max_los,
-                    );
-                }))
-            })
-            .collect::<Result<Vec<_>>>();
+                    Ok(s.spawn(move || {
+                        kernel_worker(
+                            &db_worker,
+                            borrow_elevations,
+                            kernel_receive,
+                            &kernel_send,
+                            config,
+                        );
+                    }))
+                })
+                .collect::<Result<Vec<_>>>();
 
             let handles = worker_handles.expect("");
 

--- a/crates/total-viewsheds/src/tile.rs
+++ b/crates/total-viewsheds/src/tile.rs
@@ -17,7 +17,7 @@ pub struct Tile {
     /// All the elevation data.
     pub data: Vec<i16>,
     /// The lat/lon coordinates of the centre of the tile.
-    pub centre: crate::projection::LatLonCoord,
+    pub centre: crate::projection::LonLatCoord,
 }
 
 impl Tile {
@@ -109,7 +109,7 @@ impl Tile {
     /// Get the lat/lon of the centre of the tile simply by dividing the extent in half. This isn't
     /// ideal as there's no guarantee that it's the same centre that the creator used to generate
     /// the tile.
-    fn get_centre_by_raster(dataset: &gdal::Dataset) -> Result<crate::projection::LatLonCoord> {
+    fn get_centre_by_raster(dataset: &gdal::Dataset) -> Result<crate::projection::LonLatCoord> {
         let (width, height) = dataset.raster_size();
 
         #[expect(
@@ -138,7 +138,7 @@ impl Tile {
             &mut converted,
         )?;
 
-        Ok(crate::projection::LatLonCoord(geo::coord! {
+        Ok(crate::projection::LonLatCoord(geo::coord! {
             x: converted.0.to_degrees(),
             y: converted.1.to_degrees()
         }))
@@ -146,7 +146,7 @@ impl Tile {
 
     /// Get the lat/lon centre of the tile by querying the projection's definition. This is more
     /// likely to guarantee that the tile's centre matches the creator's intended centre.
-    fn get_centre_by_projection(dataset: &gdal::Dataset) -> Result<crate::projection::LatLonCoord> {
+    fn get_centre_by_projection(dataset: &gdal::Dataset) -> Result<crate::projection::LonLatCoord> {
         let projection = &dataset.spatial_ref()?.to_proj4()?;
 
         let lat_0: f64 = projection
@@ -163,7 +163,7 @@ impl Tile {
             .and_then(|value| value.parse::<f64>().ok())
             .context("Couldn't find `lon_0` in projection defintion")?;
 
-        Ok(crate::projection::LatLonCoord(
+        Ok(crate::projection::LonLatCoord(
             geo::coord! { x: lon_0, y: lat_0 },
         ))
     }
@@ -183,7 +183,7 @@ mod test {
         let tile = Tile::load(&config).unwrap();
         assert_eq!(
             tile.centre,
-            crate::projection::LatLonCoord(geo::Coord {
+            crate::projection::LonLatCoord(geo::Coord {
                 x: -0.1278,
                 y: 51.5074
             })
@@ -199,7 +199,7 @@ mod test {
         let tile = Tile::load(&config).unwrap();
         assert_eq!(
             tile.centre,
-            crate::projection::LatLonCoord(geo::Coord {
+            crate::projection::LonLatCoord(geo::Coord {
                 x: -0.1278,
                 y: 51.5074
             })


### PR DESCRIPTION
So for Galiano Island for example you can use these CLI args to not compute any points outside of the defined polygon.

```
  --aoi-point -123.57209623620894,49.02110568820024 \
  --aoi-point -123.29132955324245,48.87887000504236 \
  --aoi-point -123.34211991205905,48.83884334550575 \
  --aoi-point -123.61305988176157,48.99841636016359 \
  --aoi-point -123.57209623620894,49.021105688200
```

Galiano 50m heatmap:
<img width="682" height="701" alt="image" src="https://github.com/user-attachments/assets/540c3feb-503e-40ec-9228-5e6ddf534b5e" />

On my local machine run time goes from 48s to 10s, an approximate 5 times speedup.

Relates to #78