### PR TITLE
Create indexes subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,9 +1438,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1907,6 +1907,7 @@ dependencies = [
  "memchr",
  "pollster",
  "proj4rs",
+ "rayon",
  "rusqlite",
  "serde",
  "serde_json",

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -26,6 +26,9 @@ function geojson_area() {
 	echo "$area"
 }
 
+sqlite_db_path="./output/benchmark.db"
+rm $sqlite_db_path || true
+
 # Do the calculations
 time cargo run --features ring_data --release -- \
 	compute "$PROJECT_ROOT/benchmarks/cardiff.tiff" \
@@ -34,7 +37,7 @@ time cargo run --features ring_data --release -- \
 	--rings-per-km 3 \
 	--backend "$backend" \
 	--process all \
-	--viewsheds-db-path ./output/viewsheds.db \
+	--viewsheds-db-path $sqlite_db_path \
 	--thread-count 1
 
 if [[ $backend == "vulkan" ]]; then
@@ -49,7 +52,7 @@ rm $viewshed_file || true
 # Reconstruct a viewshed from the centre of the DEM
 if [[ $backend == "cpu" ]]; then
 	time cargo run --release -- \
-		viewshed ./output/viewsheds.db ./output \
+		viewshed $sqlite_db_path ./output \
 		-- -3.1230,51.4898
 else
 	time cargo run --release -- \

--- a/crates/total-viewsheds/Cargo.toml
+++ b/crates/total-viewsheds/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 wgpu = { version = "27", default-features = false, features = ["spirv", "vulkan"] }
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 memchr = "2.8.0"
+rayon = "1.12.0"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/crates/total-viewsheds/src/config.rs
+++ b/crates/total-viewsheds/src/config.rs
@@ -23,6 +23,8 @@ pub enum Commands {
     Compute(Compute),
     /// Reconstruct a viewshed.
     Viewshed(Viewshed),
+    /// Post-processing tasks
+    PostProcess(PostProcess),
 
     /// A hidden command that can be used to recursively print out all the subcommand help messages:
     ///   `cargo run dump-usage`
@@ -163,6 +165,18 @@ pub struct Viewshed {
     /// Coordinates to reconstruct viewsheds for.
     #[arg(value_parser = parse_coords)]
     pub coordinates: Vec<(f32, f32)>,
+}
+
+/// Arguments to the `post-process` subcommand.
+#[derive(clap::Parser, Debug)]
+pub struct PostProcess {
+    /// Directory where viewshed DBs were saved.
+    #[arg(value_name = "Path to existing databases")]
+    pub db_dir: std::path::PathBuf,
+
+    /// Number of threads to use. Defaults to letting Rayon choose the thread count.
+    #[arg(long, value_name = "Number of threads to use")]
+    pub threads: Option<usize>,
 }
 
 /// Parse args like "123.456,-987.654" to floats.

--- a/crates/total-viewsheds/src/main.rs
+++ b/crates/total-viewsheds/src/main.rs
@@ -68,6 +68,7 @@ mod cpu {
 mod dem;
 mod dump_usage;
 mod los_pack;
+mod post_process;
 mod tile;
 mod vulkan;
 /// Various ways to output data.
@@ -110,6 +111,9 @@ fn main() -> Result<()> {
                     geo_coord,
                 )?;
             }
+        }
+        config::Commands::PostProcess(post_process_config) => {
+            post_process::run(post_process_config)?;
         }
         config::Commands::DumpUsage => dump_usage::dump_full_usage_for_readme()?,
     }

--- a/crates/total-viewsheds/src/post_process.rs
+++ b/crates/total-viewsheds/src/post_process.rs
@@ -1,0 +1,67 @@
+//! Post-processing work after doing a compute run to generate viewshed databases.
+
+use color_eyre::Result;
+use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
+
+/// Run post-processing tasks.
+pub fn run(config: &crate::config::PostProcess) -> Result<()> {
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "It's too verbose"
+    )]
+    let paths: Vec<_> = std::fs::read_dir(&config.db_dir)?
+        .filter_map(|result| result.ok())
+        .map(|file| file.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "db"))
+        .collect();
+
+    tracing::info!(
+        "Found {} shards. Starting parallel indexing...",
+        paths.len()
+    );
+
+    if let Some(threads) = config.threads {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build_global()?;
+    }
+
+    paths.par_iter().for_each(|path| {
+        if let Err(error) = index_one_shard(path) {
+            tracing::error!("Error indexing {:?}: {}", path.file_name(), error);
+        } else {
+            tracing::info!("Finished: {:?}", path.file_name());
+        }
+    });
+
+    tracing::info!("Indexing complete.");
+    Ok(())
+}
+
+/// Carry out indexing and cleanup for a single database.
+fn index_one_shard(path: &std::path::Path) -> rusqlite::Result<()> {
+    let conn = rusqlite::Connection::open(path)?;
+
+    conn.execute_batch(
+        "
+        PRAGMA journal_mode = OFF;
+        PRAGMA synchronous = OFF;
+        ",
+    )?;
+
+    tracing::debug!("Creating indexes for {path:?}...");
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS dem_id__index ON polar_segments(dem_id)",
+        [],
+    )?;
+
+    tracing::debug!("Analyzing {path:?}...");
+    conn.execute("ANALYZE", [])?;
+
+    // Why we don't VACCUM:
+    // It will attempt to copy the newly indexed database over to a new file, rebuilding the indexes
+    // and re-packing the data in the process. This is overzelous for our needs, so we do not need it.
+    // This also allows us to need less special PRAGMAs used for copying, because we aren't copying.
+
+    Ok(())
+}


### PR DESCRIPTION
I've been running locally like `cargo run --release post-process output/split --threads 3`. Without the `--threads` argument Rayon decides the optimal count.