### PR TITLE
feat: Only save largest viewsheds in neighbourhood

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = [
 [workspace.lints.rust]
 # It's always good to write as much documentation as possible
 missing_docs = "warn"
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_arch, values("spirv"))'] }
 
 [workspace.lints.clippy]
 # `clippy::all` is already on by default. It implies the following:

--- a/crates/total-viewsheds/src/compute/kernel.rs
+++ b/crates/total-viewsheds/src/compute/kernel.rs
@@ -147,14 +147,50 @@ pub fn kernel(
                         angle as u16,
                     ));
                 };
-                if cfg!(any(test, feature = "ring_data"))
-                    && crate::run::Compute::is_process_viewsheds(&config.process)
-                {
-                    db_worker.store_bitmap(result_dem_id as u64, angle as u16, &point_visibility);
+                let mut maybe_neighbourhood_id = None;
+                if is_save_viewshed(config, result_dem_id, &mut maybe_neighbourhood_id) {
+                    db_worker.store_bitmap(
+                        result_dem_id as u64,
+                        maybe_neighbourhood_id,
+                        angle as u16,
+                        &point_visibility,
+                    );
                 }
             }
         }
     }
+}
+
+/// Decide whether to save viewshed data to disk.
+fn is_save_viewshed(
+    config: &crate::run::Config,
+    dem_id: i64,
+    maybe_neighbourhood_id: &mut Option<i64>,
+) -> bool {
+    if !cfg!(any(test, feature = "ring_data")) {
+        return false;
+    }
+    if !crate::run::Compute::is_process_viewsheds(&config.process) {
+        return false;
+    }
+
+    if let Some(whitelist) = &config.viewsheds_to_save {
+        let neighbourhood_id = crate::pre_process::get_neighbourhood_id(
+            dem_id,
+            i64::from(config.dem_metadata.width),
+            i64::from(config.dem_metadata.neighbourhood_size),
+        );
+        if let Some(biggest) = whitelist.get(&neighbourhood_id)
+            && &dem_id == biggest
+        {
+            *maybe_neighbourhood_id = Some(neighbourhood_id);
+            return true;
+        }
+    } else {
+        return true;
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -174,6 +210,7 @@ mod test {
             scale: 1.0,
             max_line_of_sight: width,
             centre: crate::projection::LonLatCoord((0.0, 0.0).into()),
+            neighbourhood_size: 0,
         };
         let config = crate::run::Config {
             dem_metadata: metadata,

--- a/crates/total-viewsheds/src/config.rs
+++ b/crates/total-viewsheds/src/config.rs
@@ -1,6 +1,6 @@
 //! Defines all the CLI arguments.
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 use std::path::PathBuf;
 
 /// `Config`
@@ -137,6 +137,15 @@ pub struct Compute {
         default_value = "false"
     )]
     pub database_per_thread: bool,
+
+    /// Provide an existing TVS heatmap .tiff as a source for directing computation.
+    #[arg(long, value_name = "Path to existing TVS .tiff")]
+    pub tvs_source_path: Option<std::path::PathBuf>,
+
+    /// Only save viewsheds with the highest surface area within a square of this size. Must be a
+    /// perfect square, eg: 4, 9, 16, etc. Requires `--tvs_source_path` argument.
+    #[arg(long, value_name = "Square size", value_parser=is_perfect_square)]
+    pub only_save_biggest_viewsheds: Option<u16>,
 }
 
 /// Arguments to the `viewshed` subcommand.
@@ -186,6 +195,16 @@ fn parse_coords(string: &str) -> Result<(f32, f32)> {
     Ok((coordinates[0], coordinates[1]))
 }
 
+/// Check if argument is a perfect square.
+fn is_perfect_square(argument: &str) -> Result<u16> {
+    let number = argument.parse::<u16>()?;
+    let root = number.isqrt();
+    if root * root != number {
+        bail!("Value must be a perfect square");
+    }
+    Ok(number)
+}
+
 /// Where to run the computations.
 #[derive(clap::ValueEnum, Clone, Debug, Default)]
 pub enum Backend {
@@ -197,7 +216,6 @@ pub enum Backend {
 }
 
 /// Which calculations to process.
-#[cfg(not(target_arch = "spirv"))]
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
 pub enum Process {
     /// Calculate everything.

--- a/crates/total-viewsheds/src/main.rs
+++ b/crates/total-viewsheds/src/main.rs
@@ -17,6 +17,7 @@
         clippy::default_numeric_fallback,
         clippy::integer_division,
         clippy::integer_division_remainder_used,
+        clippy::indexing_slicing,
         reason = "It's just for the tests"
     )
 )]
@@ -24,12 +25,18 @@
 extern crate core;
 
 use clap::Parser as _;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 use std::mem;
 use tracing_subscriber::{Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 mod config;
+mod dem;
+mod dump_usage;
+mod los_pack;
+mod post_process;
+mod pre_process;
 mod run;
+mod tile;
 mod workers;
 
 /// cpu implements a CPU kernel for the longest line of sight
@@ -53,10 +60,7 @@ mod compute {
 
     pub use kernel::kernel;
 }
-mod dem;
-mod dump_usage;
-mod los_pack;
-mod post_process;
+
 /// Database for viewsheds
 mod storage {
     pub mod db;
@@ -65,7 +69,6 @@ mod storage {
     pub mod segments;
     pub mod worker;
 }
-mod tile;
 
 /// Various ways to output data.
 mod output {
@@ -92,7 +95,7 @@ fn main() -> Result<()> {
                     geo::coord! {x: f64::from(coordinate.0), y: f64::from(coordinate.1)},
                 );
 
-                let viewshed = crate::output::viewshed::Viewshed::reconstruct(
+                let (_, viewshed) = crate::output::viewshed::Viewshed::reconstruct(
                     viewshed_config.db_path.clone(),
                     geo_coord,
                 )?;
@@ -153,6 +156,17 @@ fn compute(config: &config::Compute) -> Result<()> {
         scale: dem.scale,
         max_line_of_sight: max_line_of_sight_as_points,
         centre: dem.centre,
+        neighbourhood_size: config.only_save_biggest_viewsheds.unwrap_or(0).into(),
+    };
+
+    let save_viewshed_dem_ids = if config.only_save_biggest_viewsheds.is_some() {
+        if config.tvs_source_path.is_none() {
+            bail!("Must provide --tvs_source_path argument");
+        }
+
+        Some(pre_process::create_biggest_tvs_subgrid(config)?)
+    } else {
+        None
     };
 
     tracing::info!("Starting computations");
@@ -171,6 +185,7 @@ fn compute(config: &config::Compute) -> Result<()> {
         )?,
         dem_metadata,
         database_per_thread: config.database_per_thread,
+        viewsheds_to_save: save_viewshed_dem_ids,
     };
 
     let mut compute = run::Compute::new(compute_config, &mut dem)?;

--- a/crates/total-viewsheds/src/output/ascii.rs
+++ b/crates/total-viewsheds/src/output/ascii.rs
@@ -21,10 +21,11 @@ pub fn make_viewshed(
         .unwrap();
 
     crate::run::test::compute(&mut dem, config.clone());
-    let mut viewshed = Viewshed::reconstruct(config.viewsheds_db_path, coord_lonlat).unwrap();
+    let (pov_coord, mut viewshed) =
+        Viewshed::reconstruct(config.viewsheds_db_path, coord_lonlat).unwrap();
     let viewsheder = crate::output::viewshed::Viewshed {
         dem: &dem,
-        pov_coord: crate::dem::Coordinate(viewshed_pov),
+        pov_coord,
     };
 
     let scale = 2;

--- a/crates/total-viewsheds/src/output/viewshed.rs
+++ b/crates/total-viewsheds/src/output/viewshed.rs
@@ -22,11 +22,11 @@ impl Viewshed<'_> {
     /// Reconstruct a viewshed.
     pub fn reconstruct(
         db_path: std::path::PathBuf,
-        pov_coord_lonlat: crate::projection::LonLatCoord,
-    ) -> Result<geo::MultiPolygon> {
+        clicked_lonlat: crate::projection::LonLatCoord,
+    ) -> Result<(crate::dem::Coordinate, geo::MultiPolygon)> {
         let db = crate::storage::db::DB::new(db_path)?;
         let metadata = db.load_metadata()?;
-        tracing::debug!("Using metadata for ring data: {:?}", metadata);
+        tracing::debug!("Using metadata: {:?}", metadata);
 
         let dem = crate::dem::DEM::new(
             metadata.centre,
@@ -35,8 +35,41 @@ impl Viewshed<'_> {
             metadata.max_line_of_sight,
         )?;
 
-        let pov_dem_coord =
-            crate::projection::Converter::lonlat_to_dem_coord(&metadata, pov_coord_lonlat)?;
+        let dem_coord =
+            crate::projection::Converter::lonlat_to_dem_coord(&metadata, clicked_lonlat)?;
+        let dem_id = dem.dem_coord_to_id(dem_coord);
+
+        let (segments, pov_dem_coord) = match metadata.neighbourhood_size {
+            0 => {
+                let id = crate::storage::db::ID::DEM(dem_id.into());
+                let (segments, _) = db.load_segments(&id)?;
+                (segments, dem_coord)
+            }
+            _ => {
+                let neighbourhood_id = crate::pre_process::get_neighbourhood_id(
+                    dem_id.into(),
+                    dem.width.into(),
+                    metadata.neighbourhood_size.into(),
+                );
+                let id = crate::storage::db::ID::Neighbourhood(neighbourhood_id);
+                let (segments, dem_id_with_biggest_viewshed) = db.load_segments(&id)?;
+                let x = dem_id_with_biggest_viewshed.rem_euclid(i64::from(dem.width));
+                let y = dem_id_with_biggest_viewshed.div_euclid(i64::from(dem.width));
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "I assume that we never hit the 52 bit mantissa limit"
+                )]
+                let coordinate = crate::dem::Coordinate(
+                    geo::coord! {
+                        x: x as f64,
+                        y: y as f64,
+                    } * f64::from(dem.scale),
+                );
+                (segments, coordinate)
+            }
+        };
+
         tracing::info!(
             "Reconstructing viewshed for DEM-relative coord: {:?}.",
             pov_dem_coord
@@ -46,13 +79,10 @@ impl Viewshed<'_> {
             dem: &dem,
             pov_coord: pov_dem_coord,
         };
-
         let mut reconstructor = Reconstructor::new(&viewshed, 0.0)?;
-
-        let segments = db.load_segments_for_tvs_id(reconstructor.pov_id)?;
         let polygon = reconstructor.parse_polar_segments(&segments);
 
-        Ok(polygon)
+        Ok((pov_dem_coord, polygon))
     }
 
     /// Convert from the viewshed projection to DEM coordinates.
@@ -85,8 +115,6 @@ impl Viewshed<'_> {
 pub struct Reconstructor<'viewshed> {
     /// Data for the entire viewshed.
     viewshed: &'viewshed Viewshed<'viewshed>,
-    /// The DEM id of the observer.
-    pov_id: u32,
     /// The current sector angle
     current_angle: f32,
 }
@@ -101,7 +129,6 @@ impl<'viewshed> Reconstructor<'viewshed> {
         let pov_id = viewshed.dem.dem_coord_to_id(viewshed.pov_coord);
         let reconstructor = Self {
             viewshed,
-            pov_id,
             current_angle: angle,
         };
 
@@ -257,7 +284,7 @@ impl<'viewshed> Reconstructor<'viewshed> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{output::ascii::assert_viewshed, run};
+    use crate::output::ascii::assert_viewshed;
 
     fn builder<'viewshed>(viewshed: &'viewshed Viewshed, angle: f32) -> Reconstructor<'viewshed> {
         Reconstructor::new(viewshed, angle).unwrap()
@@ -389,14 +416,29 @@ mod test {
         }
     }
 
+    const SUMMIT_VIEWSHED: [&str; 12] = [
+        "████████████████████████",
+        "████████████████████████",
+        "███████▀▀ ▄▄▄▄▄ ▀▀██████",
+        "█████▀ ▄█████████▄ ▀████",
+        "████▀ █████████████ ▀███",
+        "████ ███████████████ ███",
+        "████ ███████████████ ███",
+        "████ ▀█████████████▀ ███",
+        "█████ ▀███████████▀ ████",
+        "██████▄ ▀▀█████▀▀ ▄█████",
+        "█████████▄▄▄▄▄▄▄████████",
+        "████████████████████████",
+    ];
+
     #[test]
     fn viewshed_in_hole() {
         let temp_db = tempfile::NamedTempFile::new().unwrap();
         let viewshed = crate::output::ascii::make_viewshed(
             &crate::tests::fixtures::bigger_dem(),
             geo::Coord { x: 5.0, y: 5.0 },
-            run::Config {
-                dem_metadata: run::test::big_dem_metadata(),
+            crate::run::Config {
+                dem_metadata: crate::run::test::big_dem_metadata(),
                 ..crate::run::test::default_config(&temp_db)
             },
         );
@@ -419,32 +461,75 @@ mod test {
     }
 
     #[test]
-    fn viewshed_on_summit() {
+    fn viewshed_on_summit_by_coord() {
         let temp_db = tempfile::NamedTempFile::new().unwrap();
         let viewshed = crate::output::ascii::make_viewshed(
             &crate::tests::fixtures::bigger_dem(),
             geo::Coord { x: 6.0, y: 6.0 },
-            run::Config {
-                dem_metadata: run::test::big_dem_metadata(),
+            crate::run::Config {
+                dem_metadata: crate::run::test::big_dem_metadata(),
                 ..crate::run::test::default_config(&temp_db)
             },
         );
+        assert_viewshed(&viewshed, &SUMMIT_VIEWSHED);
+    }
 
-        let expected = [
-            "████████████████████████",
-            "████████████████████████",
-            "███████▀▀ ▄▄▄▄▄ ▀▀██████",
-            "█████▀ ▄█████████▄ ▀████",
-            "████▀ █████████████ ▀███",
-            "████ ███████████████ ███",
-            "████ ███████████████ ███",
-            "████ ▀█████████████▀ ███",
-            "█████ ▀███████████▀ ████",
-            "██████▄ ▀▀█████▀▀ ▄█████",
-            "█████████▄▄▄▄▄▄▄████████",
-            "████████████████████████",
-        ];
-        assert_viewshed(&viewshed, &expected);
+    #[test]
+    fn viewshed_on_summit_by_neighbourhood() {
+        let temp_db_for_surfaces = tempfile::NamedTempFile::new().unwrap();
+        let neighbourhood_size = 16;
+        let elevations = crate::tests::fixtures::bigger_dem();
+
+        let viewsheds_to_save = {
+            let config_for_heatmap_only = crate::run::Config {
+                dem_metadata: crate::run::test::big_dem_metadata(),
+                ..crate::run::test::default_config(&temp_db_for_surfaces)
+            };
+            let mut dem = crate::run::test::make_dem(&elevations);
+            let compute = crate::run::test::compute(&mut dem, config_for_heatmap_only);
+
+            let tiff = crate::tests::fixtures::create_tvs_tiff(compute.total_surfaces).unwrap();
+            crate::pre_process::find_biggest_total_surfaces(&tiff, neighbourhood_size).unwrap()
+        };
+
+        assert_eq!(viewsheds_to_save[&4], 78);
+
+        let temp_db_for_viewsheds = tempfile::NamedTempFile::new().unwrap();
+        let config = crate::run::Config {
+            dem_metadata: crate::storage::metadata::MetaData {
+                neighbourhood_size: neighbourhood_size.try_into().unwrap(),
+                ..crate::run::test::big_dem_metadata()
+            },
+            viewsheds_to_save: Some(viewsheds_to_save),
+            ..crate::run::test::default_config(&temp_db_for_viewsheds)
+        };
+
+        assert_viewshed(
+            &crate::output::ascii::make_viewshed(
+                &elevations,
+                geo::Coord { x: 5.0, y: 5.0 },
+                config.clone(),
+            ),
+            &SUMMIT_VIEWSHED,
+        );
+
+        assert_viewshed(
+            &crate::output::ascii::make_viewshed(
+                &elevations,
+                geo::Coord { x: 6.0, y: 6.0 },
+                config.clone(),
+            ),
+            &SUMMIT_VIEWSHED,
+        );
+
+        assert_viewshed(
+            &crate::output::ascii::make_viewshed(
+                &elevations,
+                geo::Coord { x: 7.0, y: 7.0 },
+                config,
+            ),
+            &SUMMIT_VIEWSHED,
+        );
     }
 
     #[test]
@@ -453,8 +538,8 @@ mod test {
         let viewshed = crate::output::ascii::make_viewshed(
             &crate::tests::fixtures::bigger_dem(),
             geo::Coord { x: 5.0, y: 6.0 },
-            run::Config {
-                dem_metadata: run::test::big_dem_metadata(),
+            crate::run::Config {
+                dem_metadata: crate::run::test::big_dem_metadata(),
                 ..crate::run::test::default_config(&temp_db)
             },
         );
@@ -482,9 +567,9 @@ mod test {
         let viewshed = crate::output::ascii::make_viewshed(
             &crate::tests::fixtures::bigger_dem(),
             geo::Coord { x: 5.0, y: 5.0 },
-            run::Config {
+            crate::run::Config {
                 observer_height: 20.0,
-                dem_metadata: run::test::big_dem_metadata(),
+                dem_metadata: crate::run::test::big_dem_metadata(),
                 ..crate::run::test::default_config(&temp_db)
             },
         );

--- a/crates/total-viewsheds/src/pre_process.rs
+++ b/crates/total-viewsheds/src/pre_process.rs
@@ -1,0 +1,123 @@
+//! Code to run before the main computations.
+
+use std::collections::HashMap;
+
+use color_eyre::eyre::{ContextCompat as _, Result};
+
+/// Create a fast lookup for deciding which points should have their viewsheds saved.
+pub fn create_biggest_tvs_subgrid(config: &crate::config::Compute) -> Result<HashMap<i64, i64>> {
+    let neighbourhood_size = config
+        .only_save_biggest_viewsheds
+        .context("Must specify --only-save-biggest-viewsheds")?;
+    let dataset = gdal::Dataset::open(&config.input)?;
+    let hashmap = find_biggest_total_surfaces(&dataset, i64::from(neighbourhood_size))?;
+
+    Ok(hashmap)
+}
+
+/// Find the biggest surface areas within a subgrid of a computed TVS heatmap .tiff.
+pub fn find_biggest_total_surfaces(
+    dataset: &gdal::Dataset,
+    neighbourhood_size: i64,
+) -> Result<HashMap<i64, i64>> {
+    let mut hashmap = HashMap::new();
+    let mut contenders = HashMap::new();
+    let size = dataset.raster_size();
+    let band = dataset.rasterband(1)?;
+    let points = band.read_as::<f32>((0, 0), size, size, None)?;
+
+    let width = i64::try_from(points.len().isqrt())?;
+    for (index_usize, point) in points.into_iter().enumerate() {
+        let dem_id = tvs_id_to_dem_id(i64::try_from(index_usize)?, width);
+        let neigbourhood_id = get_neighbourhood_id(dem_id, width * 3, neighbourhood_size);
+        if let Some(contender) = contenders.get_mut(&neigbourhood_id) {
+            if &point > contender {
+                *contender = point;
+                hashmap
+                    .entry(neigbourhood_id)
+                    .and_modify(|entry| *entry = dem_id);
+            }
+        } else {
+            contenders.insert(neigbourhood_id, point);
+            hashmap.insert(neigbourhood_id, dem_id);
+        }
+    }
+
+    Ok(hashmap)
+}
+
+/// Find which neighbourhood a given index is in.
+pub const fn get_neighbourhood_id(index: i64, global_width: i64, neighbourhood_size: i64) -> i64 {
+    let global_x = index.rem_euclid(global_width);
+    let global_y = index.div_euclid(global_width);
+
+    let neighbourhood_width = neighbourhood_size.isqrt();
+    let neighbourhoods_per_row = global_width.div_euclid(neighbourhood_width);
+    let neighbourhood_x = global_x.div_euclid(neighbourhood_width);
+    let neighbourhood_y = global_y.div_euclid(neighbourhood_width);
+    (neighbourhood_y * neighbourhoods_per_row) + neighbourhood_x
+}
+
+/// Convert a TVS ID to a DEM ID.
+const fn tvs_id_to_dem_id(tvs_id: i64, width: i64) -> i64 {
+    let tvs_x = tvs_id.rem_euclid(width);
+    let tvs_y = tvs_id.div_euclid(width);
+    let dem_x = tvs_x + width;
+    let dem_y = tvs_y + width;
+    let dem_width = width * 3;
+    (dem_y * dem_width) + dem_x
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn tvs_neighbourhood_id() {
+        fn run(index: i64) -> i64 {
+            let global_width = 20;
+            let neighbourhood_size = 16;
+            get_neighbourhood_id(index, global_width, neighbourhood_size)
+        }
+
+        assert_eq!(run(0), 0);
+        assert_eq!(run(3), 0);
+        assert_eq!(run(60), 0);
+        assert_eq!(run(63), 0);
+
+        assert_eq!(run(4), 1);
+        assert_eq!(run(44), 1);
+
+        assert_eq!(run(19), 4);
+        assert_eq!(run(79), 4);
+
+        assert_eq!(run(80), 5);
+        assert_eq!(run(83), 5);
+
+        assert_eq!(run(383), 20);
+
+        assert_eq!(run(399), 24);
+        assert_eq!(run(400), 25);
+    }
+
+    #[test]
+    fn biggest_total_surfaces_subgrid() {
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "Just tests, these aren't big values"
+        )]
+        let data = (0..400).map(|i| i as f32).collect();
+        let dataset = crate::tests::fixtures::create_tvs_tiff(data).unwrap();
+        let hashmap = find_biggest_total_surfaces(&dataset, 16).unwrap();
+
+        // Top left
+        assert!(!hashmap.contains_key(&79));
+        assert_eq!(hashmap[&80], 1403);
+        assert_eq!(hashmap[&81], 1407);
+
+        // Bottom right
+        assert_eq!(hashmap[&143], 2375);
+        assert_eq!(hashmap[&144], 2379);
+        assert!(!hashmap.contains_key(&145));
+    }
+}

--- a/crates/total-viewsheds/src/projection.rs
+++ b/crates/total-viewsheds/src/projection.rs
@@ -203,6 +203,7 @@ mod test {
             scale: 5.0,
             max_line_of_sight: 250,
             centre,
+            neighbourhood_size: 0,
         };
 
         assert_eq!(

--- a/crates/total-viewsheds/src/run.rs
+++ b/crates/total-viewsheds/src/run.rs
@@ -43,6 +43,8 @@ pub struct Config {
     pub area_of_interest: geo::Polygon,
     /// Should a database aggregate per thread?
     pub database_per_thread: bool,
+    /// DEM IDs to save viewsheds for.
+    pub viewsheds_to_save: Option<std::collections::HashMap<i64, i64>>,
 }
 
 impl<'compute> Compute<'compute> {
@@ -71,13 +73,6 @@ impl<'compute> Compute<'compute> {
     /// Are we computing viewsheds?
     pub fn is_process_viewsheds(process: &[crate::config::Process]) -> bool {
         Self::is_process_everything(process) || process.contains(&crate::config::Process::Viewsheds)
-    }
-
-    /// Do all computations.
-    pub fn run(&mut self) -> Result<()> {
-        self.run_parallel()?;
-
-        Ok(())
     }
 
     /// Render a heatmap and `.tiff` file of the total surface areas for each point within the computable area of the
@@ -205,6 +200,7 @@ pub mod test {
             dem_metadata: default_metadata(),
             area_of_interest: geo::Polygon::empty(),
             database_per_thread: false,
+            viewsheds_to_save: None,
         }
     }
 

--- a/crates/total-viewsheds/src/storage/db.rs
+++ b/crates/total-viewsheds/src/storage/db.rs
@@ -3,6 +3,15 @@
 use color_eyre::Result;
 use std::path::Path;
 
+/// How we look up polar segments in the database.
+#[derive(Debug)]
+pub enum ID {
+    /// The precise DEM ID of the polar segment.
+    DEM(i64),
+    /// The neighbourhood ID within which a single DEM ID has been isolated.
+    Neighbourhood(i64),
+}
+
 /// Sqlite DB connection details.
 pub struct DB {
     /// A connection to Sqlite
@@ -24,7 +33,8 @@ impl DB {
             "
             CREATE TABLE IF NOT EXISTS metadata (
                 json TEXT NOT NULL
-            )",
+            )
+            ",
             (),
         )?;
 
@@ -51,30 +61,30 @@ impl DB {
         Ok(metadata)
     }
 
-    /// Load all the polar segments for a given DEM ID.
-    pub fn load_segments_for_tvs_id(
-        &self,
-        tvs_id: u32,
-    ) -> Result<Vec<Vec<super::segments::Segment>>> {
+    /// Load all the polar segments for a given ID.
+    pub fn load_segments(&self, id: &ID) -> Result<(Vec<Vec<super::segments::Segment>>, i64)> {
         tracing::debug!(
-            "Loading polar segments for {tvs_id} from {:?}...",
+            "Loading polar segments for {id:?} from {:?}...",
             self.connection.path()
         );
 
-        // We use `MIN(...)` because it's possible that for any given DEM ID and angle, there can
-        // be mulitple records. This is because of how DEM rotation is quantised to the resolution
-        // of the grid. It is assumed that each of these duplicates have approximately the same
-        // viewshed segements.
-        let mut statement = self.connection.prepare(
+        let (field, id_value) = match id {
+            ID::DEM(value) => ("dem_id", value),
+            ID::Neighbourhood(value) => ("neighbourhood_id", value),
+        };
+
+        let statement = format!(
             "
-            SELECT MIN(visible_segments) AS visible_segments
+            SELECT visible_segments
             FROM polar_segments
-            WHERE dem_id = ?1
+            WHERE {field} = ?1
             GROUP BY angle_id
             ORDER BY angle_id ASC;
-            ",
-        )?;
-        let rows = statement.query_map([tvs_id], |row| {
+            "
+        );
+
+        let mut prepared = self.connection.prepare(&statement)?;
+        let rows = prepared.query_map([id_value], |row| {
             let blob: Vec<u8> = row.get(0)?;
             Ok(blob)
         })?;
@@ -84,7 +94,24 @@ impl DB {
             segments.push(Self::bytes_to_segments(&row?)?);
         }
 
-        Ok(segments)
+        let dem_id = match id {
+            ID::DEM(dem_id) => *dem_id,
+            ID::Neighbourhood(neighbourhood_id) => self
+                .connection
+                .prepare(
+                    "
+                    SELECT dem_id FROM polar_segments
+                    WHERE neighbourhood_id = ?1
+                    LIMIT 1
+                    ",
+                )?
+                .query_row([neighbourhood_id], |row| {
+                    let dem_id: i64 = row.get(0)?;
+                    Ok(dem_id)
+                })?,
+        };
+
+        Ok((segments, dem_id))
     }
 
     /// Convert blob to `Segment`s.

--- a/crates/total-viewsheds/src/storage/engine.rs
+++ b/crates/total-viewsheds/src/storage/engine.rs
@@ -11,13 +11,24 @@ where
     Self: Send + Sync,
 {
     /// The
-    fn store_segments(&self, tvs_id: u64, segments: super::segments::PolarSegments);
+    fn store_segments(
+        &self,
+        dem_id: u64,
+        neighbourhood_id: Option<i64>,
+        segments: super::segments::PolarSegments,
+    );
 }
 
 /// `NoopEngine` stores no `PolarSegments`, it exists for testing purposes
 pub struct Noop;
 impl Engine for Noop {
-    fn store_segments(&self, _tvs_id: u64, _segments: super::segments::PolarSegments) {}
+    fn store_segments(
+        &self,
+        _dem_id: u64,
+        _neighbourhood_id: Option<i64>,
+        _segments: super::segments::PolarSegments,
+    ) {
+    }
 }
 
 /// Stores all `PolarSegments` in a sqlite database. It uses a channel to communicate with a worker thread
@@ -44,7 +55,7 @@ pub struct Sqlite {
     /// meaning so long as `SqliteEngine` isn't being dropped it is `Some`
     worker_handle: Option<thread::JoinHandle<Result<(), rusqlite::Error>>>,
     /// `sender` is a mpsc channel that communicates segments to store to the `worker_handle`
-    sender: mpsc::SyncSender<(u64, super::segments::PolarSegments)>,
+    sender: mpsc::SyncSender<(u64, Option<i64>, super::segments::PolarSegments)>,
 }
 
 impl Sqlite {
@@ -66,13 +77,18 @@ impl Sqlite {
 }
 
 impl Engine for Sqlite {
-    fn store_segments(&self, tvs_id: u64, segments: super::segments::PolarSegments) {
+    fn store_segments(
+        &self,
+        dem_id: u64,
+        neighbourhood_id: Option<i64>,
+        segments: super::segments::PolarSegments,
+    ) {
         #[expect(
             clippy::expect_used,
             reason = "we should crash to make sure not to deadlock"
         )]
         self.sender
-            .send((tvs_id, segments))
+            .send((dem_id, neighbourhood_id, segments))
             .expect("channel sending error in sqlite engine");
     }
 }

--- a/crates/total-viewsheds/src/storage/metadata.rs
+++ b/crates/total-viewsheds/src/storage/metadata.rs
@@ -13,4 +13,7 @@ pub struct MetaData {
     /// The lat/lon coordinates for the centre of the 2D DEM grid. Used for accurately converting
     /// between degree and metric coordinate systems.
     pub centre: crate::projection::LonLatCoord,
+    /// The size of the region (in raster points) within which we will find the viewsheds with the
+    /// largest surface area. Used for reducing the final size of viewshed data saved to disk.
+    pub neighbourhood_size: u32,
 }

--- a/crates/total-viewsheds/src/storage/worker.rs
+++ b/crates/total-viewsheds/src/storage/worker.rs
@@ -36,9 +36,16 @@ impl Worker {
     }
 
     /// `store_bitmap` converts a bitmap into `PolarSegments` and uses its `Engine` to store it
-    pub fn store_bitmap(&self, dem_id: u64, angle: u16, bitmap: &[bool]) {
+    pub fn store_bitmap(
+        &self,
+        dem_id: u64,
+        neighbourhood_id: Option<i64>,
+        angle: u16,
+        bitmap: &[bool],
+    ) {
         self.engine.store_segments(
             dem_id,
+            neighbourhood_id,
             super::segments::PolarSegments::from_bools(angle, bitmap),
         );
     }
@@ -52,7 +59,7 @@ impl Worker {
 /// overhead. This means that any panic or error will end in a corrupted database
 pub fn writer<P: AsRef<std::path::Path>>(
     path: P,
-    recv: std::sync::mpsc::Receiver<(u64, super::segments::PolarSegments)>,
+    recv: std::sync::mpsc::Receiver<(u64, Option<i64>, super::segments::PolarSegments)>,
 ) -> Result<(), rusqlite::Error> {
     let mut conn = rusqlite::Connection::open(path)?;
 
@@ -60,6 +67,7 @@ pub fn writer<P: AsRef<std::path::Path>>(
         "
         CREATE TABLE IF NOT EXISTS polar_segments (
             dem_id INTEGER,
+            neighbourhood_id INTEGER,
             angle_id INTEGER,
             visible_segments BLOB
         )",
@@ -72,10 +80,12 @@ pub fn writer<P: AsRef<std::path::Path>>(
 
     {
         let mut stmt = tx.prepare(
-            "INSERT INTO polar_segments(dem_id, angle_id, visible_segments) VALUES (?1, ?2, ?3)",
+            "INSERT INTO polar_segments(
+               dem_id, neighbourhood_id, angle_id, visible_segments
+            ) VALUES (?1, ?2, ?3, ?4)",
         )?;
 
-        for (tvs_id, segments) in recv {
+        for (dem_id, neighbourhood_id, segments) in recv {
             #[expect(clippy::big_endian_bytes, reason = "it is documented in the format")]
             let vec_bytes = segments
                 .visible_segments
@@ -83,7 +93,12 @@ pub fn writer<P: AsRef<std::path::Path>>(
                 .flat_map(|vector| vector.0.to_be_bytes())
                 .collect::<Vec<_>>();
 
-            let params = (&tvs_id.cast_signed(), &segments.degree, &vec_bytes);
+            let params = (
+                &dem_id.cast_signed(),
+                neighbourhood_id,
+                &segments.degree,
+                &vec_bytes,
+            );
             stmt.execute(params)?;
         }
     }

--- a/crates/total-viewsheds/src/tests/fixtures.rs
+++ b/crates/total-viewsheds/src/tests/fixtures.rs
@@ -1,5 +1,7 @@
 //! Test fixtures
 
+use color_eyre::eyre::Result;
+
 /// The nodata value from NASA's SRTM data.
 pub const NODATA: f32 = -32768.0;
 
@@ -77,4 +79,16 @@ pub fn bigger_dem() -> Vec<i16> {
         0,0,3,4, 2,2,1,2, n,n,n,n,
         3,0,2,3, 1,0,1,0, n,n,n,n,
     ]
+}
+
+/// Create the TVS heatmap that a compute run outputs.
+pub fn create_tvs_tiff(data: Vec<f32>) -> Result<gdal::Dataset> {
+    let width = data.len().isqrt();
+    let driver = gdal::DriverManager::get_driver_by_name("MEM")?;
+    let dataset = driver.create_with_band_type::<f32, _>("", width, width, 1)?;
+    let mut buffer = gdal::raster::Buffer::new((width, width), data);
+    let mut band = dataset.rasterband(1)?;
+    band.write((0, 0), (width, width), &mut buffer)?;
+
+    Ok(dataset)
 }

--- a/crates/total-viewsheds/src/workers.rs
+++ b/crates/total-viewsheds/src/workers.rs
@@ -92,7 +92,7 @@ pub fn init_worker<P: AsRef<Path>>(
 impl super::run::Compute<'_> {
     /// `run_parallel` runs the CPU kernel in parallel
     #[expect(clippy::expect_used, reason = "We need to panic on failure")]
-    pub fn run_parallel(&mut self) -> Result<()> {
+    pub fn run(&mut self) -> Result<()> {
         let max_los = usize::try_from(self.dem.max_los_as_points)?;
 
         let elevations = &self.dem.elevations;


### PR DESCRIPTION
Adds 2 new arguments:

```rust
/// Provide an existing TVS heatmap .tiff as a source for directing computation.
#[arg(long, value_name = "Path to existing TVS .tiff")]
pub tvs_source_path: Option<std::path::PathBuf>,

/// Only save viewsheds with the highest surface area within a square of this size. Must be a
/// perfect square, eg: 4, 9, 16, etc. Requires --tvs_source_path argument.
#[arg(long, value_name = "Square size", value_parser=is_perfect_square)]
pub only_save_biggest_viewsheds: Option<u16>
```

The main issue I have with this PR is that it adds a field to the DB structure:
```rust
CREATE TABLE IF NOT EXISTS polar_segments (
    dem_id INTEGER,
    neighbourhood_id INTEGER,
    angle_id INTEGER,
    visible_segments BLOB
)
```
Whilst this is required for storing viewsheds by neighbourhood, it adds an unnecessary NULL byte per row for storing viewsheds normally. The fix is simple enough, to just duplicate some of the DB code so we `CREATE` and `INSERT` differently for each approach. I haven't implemented that yet because it's not yet certain that we will stay with the DB approach long term.