### PR TITLE
fix: use --tvs-source-path for neighbourhood viewsheds

### DIFF
--- a/crates/total-viewsheds/src/config.rs
+++ b/crates/total-viewsheds/src/config.rs
@@ -82,7 +82,7 @@ pub struct Compute {
     )]
     pub process: Vec<Process>,
 
-    /// The input DEM file. Currently only `.hgt` files are supported.
+    /// The input DEM file. Can be of any file type supported by GDAL.
     #[arg(value_name = "Path to the DEM file")]
     pub input: std::path::PathBuf,
 

--- a/crates/total-viewsheds/src/pre_process.rs
+++ b/crates/total-viewsheds/src/pre_process.rs
@@ -9,7 +9,11 @@ pub fn create_biggest_tvs_subgrid(config: &crate::config::Compute) -> Result<Has
     let neighbourhood_size = config
         .only_save_biggest_viewsheds
         .context("Must specify --only-save-biggest-viewsheds")?;
-    let dataset = gdal::Dataset::open(&config.input)?;
+    let tvs_source_path = config
+        .tvs_source_path
+        .clone()
+        .context("Must specify --tvs-source-path")?;
+    let dataset = gdal::Dataset::open(&tvs_source_path)?;
     let hashmap = find_biggest_total_surfaces(&dataset, i64::from(neighbourhood_size))?;
 
     Ok(hashmap)


### PR DESCRIPTION
Previously it was just using the DEM itself as the source.